### PR TITLE
remove maxconn from backend

### DIFF
--- a/templates/backend.cfg
+++ b/templates/backend.cfg
@@ -12,7 +12,7 @@
 
     {%- if item.servers is defined -%}
     {%- for server in item.servers -%}
-        server {{ server.name }} {{ server.ip }}{% if server.port is defined %}:{{server.port }}{% endif %} {% if server.maxconn is defined %}maxconn {{server.maxconn }} {% endif %}{% if server.params is defined %}{% for param in server.params %}{{ param }} {% endfor %}{% endif %}
+        server {{ server.name }} {{ server.ip }}{% if server.port is defined %}:{{server.port }}{% endif %} {% if server.params is defined %}{% for param in server.params %}{{ param }} {% endfor %}{% endif %}
 
     {% endfor -%}
     {% endif -%}


### PR DESCRIPTION
using a global context maxconn on a per-backend server basis is oversized; let maxconn be frontend and global based and evenly divied up among backends.